### PR TITLE
Fix rake task avalon:wipeout

### DIFF
--- a/lib/tasks/wipeout.rake
+++ b/lib/tasks/wipeout.rake
@@ -12,6 +12,8 @@
 #   specific language governing permissions and limitations under the License.
 # ---  END LICENSE_HEADER BLOCK  ---
 
+require 'active_fedora/cleaner'
+
 def wipeout_fedora
   ActiveFedora::Cleaner.clean!
 end


### PR DESCRIPTION
This rake task fails with uninitialized constant ActiveFedora::Cleaner. Just
need to require it in the relevant rake task.