### PR TITLE
Add Wrapper Validation For Required Fields Within A Fileset

### DIFF
--- a/app/models/mars_manifest.rb
+++ b/app/models/mars_manifest.rb
@@ -54,7 +54,7 @@ class MarsManifest
       # TODO: Stop bypassing SSL check.
 
       # sub out vertical tabs, they are expected in mars exports
-      @raw_data ||=  open(url, { ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE }).read.gsub(/\t/, "\n")
+      @raw_data ||=  open(url, { ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE }).read.gsub(/[\t\v]/, " ")
     rescue => e
       add_error(:url, "Invalid Manifest URL: '#{url}'")
     end


### PR DESCRIPTION
To allow for empty fileset-field cells within a row (because another row contains data for the fileset column we are trying to validate), this adds a validation method `validate_presence_within_fileset`, which:

-checks cells to the left and right of the currently-validating field, within the current row, looking for the presence of any data within the current fileset
-this allows us to determine whether or not the `validate_presence` validation should be run for the current field


Also adds gsub to replace tab characters with newlines, because Mars uses vertical tabs in open-ended description fields