### PR TITLE
Correct Encoding For All Values In Payload, After Hash.new() call

### DIFF
--- a/app/models/mars_ingest.rb
+++ b/app/models/mars_ingest.rb
@@ -5,6 +5,10 @@ class MarsIngest < ActiveRecord::Base
   after_create do
     manifest.rows.each do |row|
       payload = ManifestToPayloadMapper.new(manifest.headers, row, submitter.user_key).payload
+
+      # # deep correct encoding of every field in hash, and sub out utf8-invalid characters
+      # payload = deep_correct_encoding(payload)
+
       mars_ingest_item = MarsIngestItem.new(row_payload: payload)
       mars_ingest_item.mars_ingest_id = id
       mars_ingest_item.save!

--- a/app/models/mars_manifest.rb
+++ b/app/models/mars_manifest.rb
@@ -112,7 +112,6 @@ class MarsManifest
         index += increment
 
         # record if we found data, which will break while loop 
-        puts "I looked at #{index} (#{headers[index]}) and found #{row[index].to_s.strip} #{row[index].to_s.strip.present?}"
         found_data = row[index].to_s.strip.present?
         break if found_data
 

--- a/app/services/manifest_to_payload_mapper.rb
+++ b/app/services/manifest_to_payload_mapper.rb
@@ -222,7 +222,7 @@ class ManifestToPayloadMapper
     end
 
     def encode_value(val)
-      val.to_s.force_encoding('UTF-8')
+      val.to_s.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')
     end
 
     # Checks for multivalued fields, turns them into arrays, and combines

--- a/app/services/manifest_to_payload_mapper.rb
+++ b/app/services/manifest_to_payload_mapper.rb
@@ -27,34 +27,9 @@ class ManifestToPayloadMapper
 
     # @payload = compact_payload(@payload)
     pl = @payload.clone
-    @payload = compact_hash(pl)
+    pl = compact_hash(pl)
+    @payload = deep_correct_encoding(pl)
   end
-
-  # def compact_payload(payload)
-  #   # cleaning up the mess
-  #   clean_payload = payload.clone
-  #   clean_payload['files'] = compact_filearray(payload['files'])
-  #   clean_payload['fields'] = compact_key(payload['fields'])
-  #   clean_payload
-  # end
-
-  # def compact_filearray(filearray)
-  #   filearray.map do |file|
-
-  #     # compact the inner files
-  #     newfilefiles = file['files'].map { |ff| compact_key(ff) }
-  #     # compact the outer files
-  #     newfile = compact_key(file)
-  #     # reassign the inner files
-  #     newfile['files'] = newfilefiles
-
-  #     newfile
-  #   end
-  # end
-
-  # def compact_key(hash)
-  #   hash.delete_if {|header, value| value == "" || value.nil? || (value.is_a?(Array) && value.all? {|v| v.nil? || v == "" })  }
-  # end
 
   def compact_hash(hash)
     newhash = {}
@@ -91,7 +66,18 @@ class ManifestToPayloadMapper
     newhash
   end
 
-
+  def deep_correct_encoding(hash)
+    hash.transform_values do |v|
+      if v.is_a?(Hash)
+        deep_correct_encoding(v)
+      elsif v.is_a?(Array)
+        v.map {|ele| ele.to_s.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?').force_encoding('UTF-8')}
+      else
+        v.to_s.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?').force_encoding('UTF-8')
+      end
+    end
+  end
+  
   private
 
     # Returns a found (or new) collection based on the collection fields and
@@ -222,7 +208,7 @@ class ManifestToPayloadMapper
     end
 
     def encode_value(val)
-      val.to_s.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')
+      val.to_s.force_encoding('UTF-8')
     end
 
     # Checks for multivalued fields, turns them into arrays, and combines


### PR DESCRIPTION
we were previously force_encoding the entire payload string to utf8, before we switched to using the json field

we preserved the running of the force_encoding method, but its getting messed up again during the Hash.new(  call right after we force encode
(new data from peter has accented characters causing crash)

this adds a deep-encode method that cleans up the whole payload just before its returned