### PR TITLE
141 add item type note

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -114,18 +114,23 @@ module ApplicationHelper
   end
 
   def search_result_label item
+
     if item['title_tesi'].present?
-      label = truncate(item['title_tesi'], length: 100)
+      # WGBH-MLA CUSTO -> show item type note along with title
+      title_and_item_type = item['title_tesi']
+      title_and_item_type += %( - #{item['item_type_note'].first}) if item['item_type_note'].first
+      label = truncate(title_and_item_type, length: 100)
     else
       label = item[:id]
     end
 
-    if item['duration_ssi'].present?
-      duration = item['duration_ssi']
-      if duration.respond_to?(:to_i) && duration.to_i > 0
-        label += " (#{milliseconds_to_formatted_time(duration.to_i, false)})"
-      end
-    end
+    # WGBH-MLA CUSTO -> because of bogus duration to make thumbnail generation work, dont show in the title
+    # if item['duration_ssi'].present?
+    #   duration = item['duration_ssi']
+    #   if duration.respond_to?(:to_i) && duration.to_i > 0
+    #     label += " (#{milliseconds_to_formatted_time(duration.to_i, false)})"
+    #   end
+    # end
 
     label
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -116,8 +116,9 @@ module ApplicationHelper
   def search_result_label item
 
     if item['title_tesi'].present?
-      # WGBH-MLA CUSTO -> show item type note along with title
       title_and_item_type = item['title_tesi']
+      
+      # WGBH-MLA CUSTO -> show item type note along with title, if available
       title_and_item_type += %( - #{item['item_type_note'].first}) if item['item_type_note'] && item['item_type_note'].first
       label = truncate(title_and_item_type, length: 100)
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -118,7 +118,7 @@ module ApplicationHelper
     if item['title_tesi'].present?
       # WGBH-MLA CUSTO -> show item type note along with title
       title_and_item_type = item['title_tesi']
-      title_and_item_type += %( - #{item['item_type_note'].first}) if item['item_type_note'].first
+      title_and_item_type += %( - #{item['item_type_note'].first}) if item['item_type_note'] && item['item_type_note'].first
       label = truncate(title_and_item_type, length: 100)
     else
       label = item[:id]

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -77,10 +77,13 @@ describe ApplicationHelper do
       mo_solr_doc = {"title_tesi" => "my_title"}
       expect(helper.search_result_label(mo_solr_doc)).not_to include("(00:00)")
     end
-    it "should return formatted title if duration is present" do
-      mo_solr_doc = {"title_tesi" => "my_title", "duration_ssi" => "1000"}
-      expect(helper.search_result_label(mo_solr_doc)).to eq("my_title (00:01)")
-    end
+
+    # WGBH-MLA customization -> we disabled this duration display in search results
+    # it "should return formatted title if duration is present" do
+    #   mo_solr_doc = {"title_tesi" => "my_title", "duration_ssi" => "1000"}
+    #   expect(helper.search_result_label(mo_solr_doc)).to eq("my_title (00:01)")
+    # end
+
     it "should return id when no title" do
       mo_solr_doc = { id: "avalon:123" }
       expect(helper.search_result_label(mo_solr_doc)).to eq("avalon:123")


### PR DESCRIPTION
Shows 'item type' value with title in CatalogController#index, if available. Removes duration display in CatalogController#index, because we've had to fill in bogus duration values to get thumbnail generation to work on ingest, and almost no records have legitimate duration values at this point.