### PR TITLE
Adds partial with fix from later version of Blacklight

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -77,7 +77,7 @@ class CatalogController < ApplicationController
     # requires valid date format...
     # config.add_facet_field 'date_sim', label: 'Date', limit: 5, date: true
 
-    config.add_facet_field 'date_sim', label: 'Date', limit: 5
+    config.add_facet_field 'date_sim', label: 'Date', limit: 5, sort: 'index'
     config.add_facet_field 'genre_sim', label: 'Genres', limit: 5, sort: 'index'
     config.add_facet_field 'collection_ssim', label: 'Collection', limit: 5, sort: 'index'
     config.add_facet_field 'language_sim', label: 'Language', limit: 5, sort: 'index'

--- a/app/views/catalog/_facet_pagination.html.erb
+++ b/app/views/catalog/_facet_pagination.html.erb
@@ -1,0 +1,24 @@
+<!-- This pulls a fix from Blacklight v7.10.0 as there was a specific fix there from
+  earlier this year for the additional </span> tags we saw on the front end.
+  Since we're pinned to < 7.0.0 I'm manually bringing this fix over.
+ -->
+
+<div class="prev_next_links btn-group pull-left">
+  <%= link_to_previous_page @pagination, raw(t('views.pagination.previous')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link', data: { ajax_modal: "preserve" } do %>
+    <%= content_tag :span, raw(t('views.pagination.previous')), class: 'disabled btn btn-disabled' %>
+  <% end %>
+
+  <%= link_to_next_page @pagination, raw(t('views.pagination.next')), params: search_state.to_h, param_name: blacklight_config.facet_paginator_class.request_keys[:page], class: 'btn btn-link',  data: { ajax_modal: "preserve" } do %>
+    <%= content_tag :span, raw(t('views.pagination.next')), class: 'disabled btn btn-disabled' %>
+  <% end %>
+</div>
+
+<div class="sort_options btn-group pull-right">
+  <% if @pagination.sort == 'index' -%>
+    <span class="active az btn btn-default"><%= t('blacklight.search.facets.sort.index') %></span>
+    <%= link_to(t('blacklight.search.facets.sort.count'), @pagination.params_for_resort_url('count', search_state.to_h), class: "sort_change numeric btn btn-default", data: { ajax_modal: "preserve" }) %>
+  <% elsif @pagination.sort == 'count' -%>
+    <%=  link_to(t('blacklight.search.facets.sort.index'), @pagination.params_for_resort_url('index', search_state.to_h), class: "sort_change az btn btn-default",  data: { ajax_modal: "preserve" }) %>
+    <span class="active numeric btn btn-default"><%= t('blacklight.search.facets.sort.count') %></span>
+  <% end -%>
+</div>


### PR DESCRIPTION
Closes #151. There's a visible span tag from this Blacklight partial that is fixed in Blacklight 7, but we're pinned to < 7.0.0. This pulls the fix in to our version of Avalon and adds a note to the partial explaining.

Also: Closes #152 for asc sort on date_sim facet.