### PR TITLE
Remove whitespace for newlines in Subject facet

### DIFF
--- a/app/assets/stylesheets/avalon/_facets.scss
+++ b/app/assets/stylesheets/avalon/_facets.scss
@@ -92,7 +92,6 @@ div[id*='facet-panel-'] {
   -o-hyphens: auto;
   hyphens: auto;
   word-wrap: break-word;
-  white-space: pre-line;
 }
 
 .facet-values .facet-label {


### PR DESCRIPTION
The CSS style white-space:pre-line; is causing newline characters to be
preserved as line breaks in the display. This is the quick and dirty fix, but
should be followed up with removing newline characters for the subject_sim
field on MediaObjects at time of ingest, along with a re-indexing job to fix
existing solr docs.

Fixes #155.