### PR TITLE
Uses Email for Username for SSO

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,7 +92,8 @@ class User < ActiveRecord::Base
   def self.find_or_create_by_username_or_email(username, email, provider = 'local')
     find_and_verify_by_username(username) ||
       find_and_verify_by_email(email) ||
-      create(username: username, email: email, password: Devise.friendly_token[0, 20], provider: provider)
+      # Overwriting Avalon to use email for username instead of the UID from Okta
+      create(username: email, email: email, password: Devise.friendly_token[0, 20], provider: provider)
   end
 
   def self.from_api_token(token)


### PR DESCRIPTION
Avalon default was to use the UID from from the SSO provider for the username in the find_or_create user method. Changes to email address.