### PR TITLE
Comments out duration checks for poster/thumbnail generation

### DIFF
--- a/app/views/media_objects/_file_upload.html.erb
+++ b/app/views/media_objects/_file_upload.html.erb
@@ -101,6 +101,9 @@ Unless required by applicable law or agreed to in writing, software distributed
                 <%= text_field_tag "master_files[#{part.id}][date_digitized]", part.date_digitized, class: 'date-input' %>
               </div>
             </div>
+            <!-- Commenting out since this fails when our ingested media object is
+              missing duration in the metadata -->
+            <!--
             <div class="col-sm-3">
               <div class="form-group">
                 <label>Thumbnail</label>
@@ -112,6 +115,7 @@ Unless required by applicable law or agreed to in writing, software distributed
                 <% end %>
               </div>
             </div>
+            -->
             <div class="col-sm-6">
               <div class="form-group">
                 <label>Permalink</label>

--- a/app/views/media_objects/_file_upload.html.erb
+++ b/app/views/media_objects/_file_upload.html.erb
@@ -101,21 +101,6 @@ Unless required by applicable law or agreed to in writing, software distributed
                 <%= text_field_tag "master_files[#{part.id}][date_digitized]", part.date_digitized, class: 'date-input' %>
               </div>
             </div>
-            <!-- Commenting out since this fails when our ingested media object is
-              missing duration in the metadata -->
-            <!--
-            <div class="col-sm-3">
-              <div class="form-group">
-                <label>Thumbnail</label>
-                <% if part.is_video? %>
-                <%= text_field_tag "master_files[#{part.id}][poster_offset]",
-                  part.poster_offset.to_i.to_hms, class: 'input-small' %>
-                <% else %>
-                <span class="input-small">n/a</span>
-                <% end %>
-              </div>
-            </div>
-            -->
             <div class="col-sm-6">
               <div class="form-group">
                 <label>Permalink</label>

--- a/spec/models/master_file_spec.rb
+++ b/spec/models/master_file_spec.rb
@@ -159,13 +159,17 @@ describe MasterFile do
         expect(master_file).to be_valid
       end
 
-      it "should complain if value < 0" do
+      # xiting since we're skipping this validation for WGBH.
+      # we don't always have a duration value on ingest.
+      xit "should complain if value < 0" do
         master_file.poster_offset = -1
         expect(master_file).not_to be_valid
         expect(master_file.errors[:poster_offset].first).to eq("must be between 0 and #{master_file.duration}")
       end
 
-      it "should complain if value > duration" do
+      # xiting since we're skipping this validation for WGBH
+      # we don't always have a duration value on ingest.
+      xit "should complain if value > duration" do
         offset = master_file.duration.to_i + rand(32514) + 500
         master_file.poster_offset = offset
         expect(master_file).not_to be_valid
@@ -181,7 +185,9 @@ describe MasterFile do
         expect(master_file).to be_valid
       end
 
-      it "should complain if value > duration" do
+      # xiting since we're skipping this validation for WGBH
+      # we don't always have a duration value on ingest.
+      xit "should complain if value > duration" do
         offset = master_file.duration.to_i + rand(32514) + 500
         master_file.poster_offset = offset.to_hms
         expect(master_file).not_to be_valid
@@ -378,11 +384,11 @@ describe MasterFile do
         class TestEncode < ActiveEncode::Base
         end
       end
-  
+
       after :all do
         Object.send(:remove_const, :TestEncode)
       end
-  
+
       it "should find the encoder class" do
         expect(Settings.encoding.engine_adapter).to eq "test"
         expect(subject.encoder_class).to eq(TestEncode)


### PR DESCRIPTION
Comments out checks on duration during poster and thumbnail generation since we oftentimes don't have the duration data or spoof it. If a user manually enters a time beyond the duration of the file, the job to update them will fail leaving the current selection. Closes #64 