### PR TITLE
Publish Media Objects and Set Visibility on Collection

### DIFF
--- a/app/services/collection_creator.rb
+++ b/app/services/collection_creator.rb
@@ -6,6 +6,6 @@ class CollectionCreator
     collection = Admin::Collection.where(name_uniq_si: collection_name.to_s.downcase.gsub(/\s/, '')).first
 
     return collection if collection
-    Admin::Collection.create!({name: collection_name, unit: unit_name, description: collection_desc, managers: [manager_user_key]})
+    Admin::Collection.create!({name: collection_name, unit: unit_name, description: collection_desc, managers: [manager_user_key], default_visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED})
   end
 end

--- a/app/services/manifest_to_payload_mapper.rb
+++ b/app/services/manifest_to_payload_mapper.rb
@@ -23,6 +23,7 @@ class ManifestToPayloadMapper
       p['fields'].merge!( notes_hash )
       p['fields'].merge!( other_id_hash )
       p['files'] = file_hashes
+      p['publish'] = "true"
     end
 
     pl = @payload.clone
@@ -37,11 +38,11 @@ class ManifestToPayloadMapper
     return false if ele == [{}]
     return false if ele == {}
     return false if ele == []
-    
+
     if ele.is_a?(Hash)
       return false unless ele.values.any? {|v| contains_truth?(v) }
     end
-    
+
     if ele.is_a?(Array)
       return false unless ele.any? {|element| contains_truth?(element) }
     end
@@ -95,10 +96,10 @@ class ManifestToPayloadMapper
       elsif v.is_a?(Array)
 
         if v.all? {|ele| ele.is_a?(Hash) }
-        
+
           v.map { |ele| deep_correct_encoding(ele) }
         else
-        
+
           v.map {|ele| ele.to_s.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?').force_encoding('UTF-8')}
         end
       else
@@ -106,7 +107,7 @@ class ManifestToPayloadMapper
       end
     end
   end
-  
+
   private
 
     # Returns a found (or new) collection based on the collection fields and
@@ -297,10 +298,10 @@ class ManifestToPayloadMapper
         'topical subject' => 'topical_subject',
         'language' => 'language',
         'table of contents' => 'table_of_contents',
-        
+
         # 'other identifier type' => 'other_identifier_type',
         # 'other identifier' => 'other_identifier',
-        # not real API field names, these are values for other_identifier_type        
+        # not real API field names, these are values for other_identifier_type
         'mla barcode' => 'videorecording identifier',
 
         'comment' => 'comment',

--- a/spec/models/mars_ingest_item_spec.rb
+++ b/spec/models/mars_ingest_item_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe MarsIngestItem do
     end
 
     it 'row_payload includes the publish flag' do
-      expect(subject.row_payload.keys).to include("publish")
+      expect(subject.row_payload["publish"]).to eq("true")
     end
   end
 end

--- a/spec/models/mars_ingest_item_spec.rb
+++ b/spec/models/mars_ingest_item_spec.rb
@@ -36,5 +36,9 @@ RSpec.describe MarsIngestItem do
       subject.row_payload.delete('files')
       expect(subject).not_to be_valid
     end
+
+    it 'row_payload includes the publish flag' do
+      expect(subject.row_payload.keys).to include("publish")
+    end
   end
 end


### PR DESCRIPTION
This PR default publishes MediaObjects during the ingest process as well as sets the default visibility for the collection and items within the Collection so that any authorized user can view the media object.