### PR TITLE
Better Handles OktaOauth Failure

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -26,6 +26,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def after_omniauth_failure_path_for(scope)
+    logger.debug "OAuth failed for #{failed_strategy.name}"
     case failed_strategy.name
     when 'lti'
       default_msg = I18n.t 'devise.omniauth_callbacks.failure', reason: failure_message
@@ -33,6 +34,9 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       uri = URI.parse request['launch_presentation_return_url']
       uri.query = {lti_errormsg: msg}.to_query
       uri.to_s
+    when 'oktaoauth'
+      msg = I18n.t 'devise.omniauth_callbacks.failure', reason: failure_message
+      root_path
     else
       new_user_session_path(scope)
     end
@@ -48,6 +52,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def find_user(auth_type)
+    logger.debug "Finding User for #{auth_type}"
     auth_type.downcase!
     find_method = "find_for_#{auth_type}".to_sym
     find_method = :find_for_generic unless User.respond_to?(find_method)

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -135,5 +135,23 @@ describe Users::OmniauthCallbacksController, type: :controller do
         expect(response).to redirect_to(root_path)
       end
     end
+
+    context 'when oktaoauth fails' do
+      def stub_route_as(path)
+        allow(@routes).to receive(:generate_extras) { [path, []] }
+      end
+
+      it 'redirects to root path' do
+        request.env['omniauth.error'] = OmniAuth::Strategies::OAuth2::CallbackError.new("User is not assigned to the client application.")
+        request.env['omniauth.error.strategy'] = OmniAuth::Strategies::Oktaoauth.new(nil)
+        stub_route_as('/users/auth/oktaoauth')
+
+        post :failure
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to match(/Unable to authorize because \"User is not assigned to the client application.\"/)
+      end
+
+    end
   end
 end


### PR DESCRIPTION
This work fixes an infinite loop error when there's an error on the Okta side of authentication. What would happen is that there would be a failure on the Okta side which would redirect back to the new_user_session path on Mlavalon which would automatically try to log back in to Okta using the same credentials. This, instead, spits them out at the root_path and exposes the error message from the Okta response.