### PR TITLE
Ruby Debian Upgrade and Github Actions for CI

### DIFF
--- a/.github/workflows/mlavalon-ci.yml
+++ b/.github/workflows/mlavalon-ci.yml
@@ -1,0 +1,18 @@
+name: CI RSpec Tests
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    name: CI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Docker compose
+        run: docker-compose up test
+
+      - name: Run Rspec specs
+        run: docker-compose exec test bash -c "bundle exec rspec"

--- a/.github/workflows/mlavalon-ci.yml
+++ b/.github/workflows/mlavalon-ci.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Docker compose
-        run: docker-compose up test
+        run: docker-compose up -d test
 
       - name: Run Rspec specs
         run: docker-compose exec test bash -c "bundle exec rspec"

--- a/.github/workflows/mlavalon-ci.yml
+++ b/.github/workflows/mlavalon-ci.yml
@@ -15,4 +15,4 @@ jobs:
         run: docker-compose up -d test
 
       - name: Run Rspec specs
-        run: docker-compose exec test bash -c "bundle exec rspec"
+        run: docker-compose exec -T test bash -c "bundle exec rspec"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # Base stage for building gems
-FROM        ruby:2.5.8-stretch as base
+FROM        ruby:2.6.8-buster as base
 ENV         BUNDLER_VERSION 2.0.2
-RUN         echo "deb http://deb.debian.org/debian stretch-backports main" >> /etc/apt/sources.list \
+RUN         echo "deb http://deb.debian.org/debian buster main" >> /etc/apt/sources.list \
+         && curl -O https://mediaarea.net/repo/deb/repo-mediaarea_1.0-19_all.deb && dpkg -i repo-mediaarea_1.0-19_all.deb \
          && apt-get update && apt-get upgrade -y build-essential \
          && apt-get install -y --no-install-recommends \
             cmake \
@@ -31,7 +32,7 @@ RUN         bundle config build.nokogiri --use-system-libraries \
 # CMD export HOME=/home/app && rm -f tmp/pids/server.pid && bundle exec rake db:migrate && bin/rails server -b 0.0.0.0
 
 # Download stage takes advantage of parallel build
-FROM        ruby:2.5.8-stretch as download
+FROM        ruby:2.6.8-buster as download
 RUN         curl https://chromedriver.storage.googleapis.com/2.46/chromedriver_linux64.zip -o /usr/local/bin/chromedriver \
          && chmod +x /usr/local/bin/chromedriver \
          && curl -L https://github.com/jwilder/dockerize/releases/download/v0.6.1/dockerize-linux-amd64-v0.6.1.tar.gz | tar xvz -C /usr/bin/ \
@@ -41,11 +42,11 @@ RUN         curl https://chromedriver.storage.googleapis.com/2.46/chromedriver_l
 
 
 # Dev stage for building dev image
-FROM        ruby:2.5.8-stretch as dev
+FROM        ruby:2.6.8-buster as dev
 ENV         BUNDLER_VERSION 2.0.2
 RUN         apt-get update && apt-get install -y --no-install-recommends curl gnupg2 \
          && curl -sL http://deb.nodesource.com/setup_8.x | bash - \
-         && curl -O https://mediaarea.net/repo/deb/repo-mediaarea_1.0-6_all.deb && dpkg -i repo-mediaarea_1.0-6_all.deb \
+         && curl -O https://mediaarea.net/repo/deb/repo-mediaarea_1.0-19_all.deb && dpkg -i repo-mediaarea_1.0-19_all.deb \
          && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
          && echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -904,9 +904,9 @@ GEM
       nokogiri (~> 1.8)
     xray-rails (0.3.2)
       rails (>= 3.1.0)
-    zk (1.9.6)
-      zookeeper (~> 1.4.0)
-    zookeeper (1.4.11)
+    zk (1.10.0)
+      zookeeper (~> 1.5.0)
+    zookeeper (1.5.0)
     zoom (0.5.0)
 
 PLATFORMS
@@ -1037,4 +1037,4 @@ DEPENDENCIES
   zoom
 
 BUNDLED WITH
-   2.2.14
+   2.2.28

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
       - npms:/home/app/avalon/node_modules
     ports:
       - '3000:3000'
-      
+
     networks:
       internal:
       external:
@@ -147,7 +147,7 @@ services:
       - redis-test
     environment:
       - DATABASE_URL=postgresql://postgres:whatever@db-test/avalon
-      - REDIS_HOST=redis-test
+      - SETTINGS__REDIS__HOST=redis-test
       - FEDORA_URL=http://fedora-test:8080/fedora/rest
       - SOLR_URL=http://solr-test:8983/solr/avalon
       - RAILS_ENV=test

--- a/spec/integration/admin_collections_controller_spec.rb
+++ b/spec/integration/admin_collections_controller_spec.rb
@@ -16,7 +16,7 @@ require 'rails_helper.rb'
 
 describe 'Admin::CollectionsController' do
   describe 'resize_uploaded_poster' do
-    let(:uploaded_file) { fixture_file_upload('/collection_poster.jpg', 'image/jpeg') }
+    let(:uploaded_file) { File.open(Rails.root.join('spec/fixtures/collection_poster.jpg')) }
     let(:controller) { Admin::CollectionsController.new }
 
     it 'successfully runs mini_magick' do


### PR DESCRIPTION
This PR uses a newer Debian distribution and uses Github Actions for running specs during CI. Closes #2335